### PR TITLE
Find address

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # These users will be the default owners for everything in the repo.
 # Unless a later match takes precedence, the following users will be
 # requested for review when someone opens a pull request.
-* @jujaga @norrisng-bc @TimCsaky @jatindersingh93 @kyle1morel @wilwong89
+* @norrisng-bc @TimCsaky @kyle1morel

--- a/app/config/custom-environment-variables.json
+++ b/app/config/custom-environment-variables.json
@@ -5,6 +5,10 @@
     "oidc": {
       "authority": "FRONTEND_OIDC_AUTHORITY",
       "clientId": "FRONTEND_OIDC_CLIENTID"
+    },
+    "geocoder": {
+      "apiKey": "FRONTEND_GEOCODER_APIKEY",
+      "apiPath": "FRONTEND_GEOCODER_APIPATH"
     }
   },
   "server": {


### PR DESCRIPTION
Adds a feature where the user can search an address in BC, and it'll be displayed (and centered) on the map as a red pin. This red pin does not persist in subsequent searches (i.e. the red pin for the previous search is cleared before the current search pin is displayed).

The GitHub CODEOWNERS file has also been updated to reflect the current innovation sprint team.