### PR TITLE
Display PID with dashes for readabilty

### DIFF
--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -217,7 +217,7 @@ onMounted(() => {
       :rows="5"
     >
       <Column
-        field="PID"
+        field="PID_FORMATTED"
         header="Parcel ID"
       ></Column>
       <Column


### PR DESCRIPTION
Just a tiny tweak to the parcel data table - in particular, displaying the dashes (i.e. XXX-XXX-XXX) so that it's more readable.